### PR TITLE
Improve deploy and alias url handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ The configuration inputs `vercelProjectID`, `vercelOrgID`, and `vercelToken` can
 
 #### Outputs
 
+- `deploymentURL`
+
+  The URL of the deployment.
+
+  Type: `string`
+
 - `deploymentTaskMessage`
 
   The output from the deployment. Can be passed to Vercel Azure DevOps Pull Request Comment Task.

--- a/vercel-deployment-task-source/task.json
+++ b/vercel-deployment-task-source/task.json
@@ -10,7 +10,7 @@
   "author": "Vercel",
   "version": {
     "Major": 1,
-    "Minor": 1,
+    "Minor": 2,
     "Patch": 0
   },
   "instanceNameFormat": "Deploying $(vercelProject) to Vercel",
@@ -60,8 +60,12 @@
   ],
   "outputVariables": [
     {
+      "name": "deploymentURL",
+      "description": "The URL of the deployment."
+    },
+    {
       "name": "deploymentTaskMessage",
-      "description": "The output from the deployment. Can be passed to Vercel Azure DevOps Pull Request Comment Task."
+      "description": "The message output from the deployment. Can be passed to Vercel Azure DevOps Pull Request Comment Task."
     }
   ],
   "execution": {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "manifestVersion": 1,
   "id": "vercel-deployment-extension",
   "name": "Vercel Deployment Extension",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "publisher": "Vercel",
   "public": true,
   "targets": [


### PR DESCRIPTION
Fixes a known bug with creating the alias URL (particularly getting the branch name)

Adds new feature, the deployment URL is now exported as a variable `deploymentURL`