### PR TITLE
Escape invalid chars in branch name using dashes

### DIFF
--- a/vercel-deployment-task-source/src/index.ts
+++ b/vercel-deployment-task-source/src/index.ts
@@ -221,7 +221,8 @@ async function run() {
           getProjectName(vercelProjectId, vercelOrgId, vercelToken),
           getStagingPrefix(vercelOrgId, vercelToken),
         ]);
-        const aliasHostname = `${projectName}-${branchName}-${stagingPrefix}.vercel.app`;
+        const escapedBranchName = branchName.replace(/[^a-z0-9\-]-?/g, '-');
+        const aliasHostname = `${projectName}-${escapedBranchName}-${stagingPrefix}.vercel.app`;
         deployURL = `https://${aliasHostname}`;
         vercel = tool(which("vercel", true));
         const vercelAliasArgs = [


### PR DESCRIPTION
If a branch name contains a forward slash, the deployment task will fail to assign the auto-generated branch alias. This PR escapes the branch name by replacing all invalid characters with a dash.