### PR TITLE
Added team scope to alias command

### DIFF
--- a/vercel-deployment-task-source/src/index.ts
+++ b/vercel-deployment-task-source/src/index.ts
@@ -230,6 +230,7 @@ async function run() {
           stdout,
           aliasHostname,
           `--token=${vercelToken}`,
+          `--scope=${vercelOrgId}`,
         ];
         if (debug) {
           vercelAliasArgs.push("--debug");

--- a/vercel-deployment-task-source/task.json
+++ b/vercel-deployment-task-source/task.json
@@ -11,7 +11,7 @@
   "version": {
     "Major": 1,
     "Minor": 2,
-    "Patch": 1
+    "Patch": 2
   },
   "instanceNameFormat": "Deploying $(vercelProject) to Vercel",
   "inputs": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "manifestVersion": 1,
   "id": "vercel-deployment-extension",
   "name": "Vercel Deployment Extension",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "publisher": "Vercel",
   "public": true,
   "targets": [


### PR DESCRIPTION
When working in a team other than a personal team, scope needs to be supplied to the alias CLI command when using an explicit token. If not, CLI will try to perform the alias on your personal account, even if it's excluded from the token scope, resulting in a "You don't have access to the domain -.app under USER" error. 

Reported by someone facing the same issue here: https://github.com/orgs/vercel/discussions/3477#discussion-5467326

Added the token scope and incremented the patch version to resolve.