### PR TITLE
Support upper case in branch names for alias

### DIFF
--- a/vercel-deployment-task-source/src/index.ts
+++ b/vercel-deployment-task-source/src/index.ts
@@ -221,7 +221,7 @@ async function run() {
           getProjectName(vercelProjectId, vercelOrgId, vercelToken),
           getStagingPrefix(vercelOrgId, vercelToken),
         ]);
-        const escapedBranchName = branchName.replace(/[^a-z0-9\-]-?/g, '-');
+        const escapedBranchName = branchName.replace(/[^a-zA-Z0-9\-]-?/g, '-');
         const aliasHostname = `${projectName}-${escapedBranchName}-${stagingPrefix}.vercel.app`;
         deployURL = `https://${aliasHostname}`;
         vercel = tool(which("vercel", true));

--- a/vercel-deployment-task-source/task.json
+++ b/vercel-deployment-task-source/task.json
@@ -11,7 +11,7 @@
   "version": {
     "Major": 1,
     "Minor": 2,
-    "Patch": 2
+    "Patch": 3
   },
   "instanceNameFormat": "Deploying $(vercelProject) to Vercel",
   "inputs": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "manifestVersion": 1,
   "id": "vercel-deployment-extension",
   "name": "Vercel Deployment Extension",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "publisher": "Vercel",
   "public": true,
   "targets": [


### PR DESCRIPTION
When running `vercel-deployment-task` against a branch whose name contains an uppercase letter, when generating the alias, the uppercase letters are replaced with hyphens instead of being allowed to propagate, despite being valid url characters.

This proposed change adds uppercase letters to the list of valid alias characters, which will correct this issue.