### PR TITLE
Truncate branchName (if necessary) to meet RFC 1035 criteria

### DIFF
--- a/vercel-deployment-task-source/src/index.ts
+++ b/vercel-deployment-task-source/src/index.ts
@@ -231,11 +231,12 @@ async function run() {
          * projectName has a fixedLength `x`
          * stagingPrefix has a fixedLenght `y`
          * .vercel.app has a fixedLength `11`
+         * two dashes
          * 
-         * escapedBranchName can have a maximum length of 63-11-y-x
+         * escapedBranchName can have a maximum length of 63-11-2-y-x
         */
         let aliasingBranchName = escapedBranchName;
-        const branchNameAllowedLength = 52-projectName.length-stagingPrefix.length;
+        const branchNameAllowedLength = 50-projectName.length-stagingPrefix.length;
         if (escapedBranchName.length > branchNameAllowedLength) {
           aliasingBranchName = aliasingBranchName.substring(0, branchNameAllowedLength);
 

--- a/vercel-deployment-task-source/src/index.ts
+++ b/vercel-deployment-task-source/src/index.ts
@@ -255,7 +255,7 @@ async function run() {
           // Calculate the maximum length of the branchName by removing the stagingPrefix and the dash
           const branchNameExtendedLength = branchNameAllowedLength+stagingPrefix.length+1;
 
-          let aliasingBranchName = escapedBranchName.substring(0, branchNameExtendedLength);;
+          let aliasingBranchName = escapedBranchName.substring(0, branchNameExtendedLength);
 
           // If, after truncation, the last character is a dash, remove it
           if (aliasingBranchName[branchNameExtendedLength] === '-') {

--- a/vercel-deployment-task-source/src/index.ts
+++ b/vercel-deployment-task-source/src/index.ts
@@ -234,18 +234,38 @@ async function run() {
          * two dashes
          * 
          * escapedBranchName can have a maximum length of 63-11-2-y-x
+         * 
+         * This can cause confusion if you have all branches following a scheme, e.g.
+         *    feature/PREFIX-12345-my-feature-branch-name
+         *    feature/PREFIX-12346-my-second-feature-branch-name
+         * 
+         * which can produce identical branchNames in the alias:
+         *    longer-project-name-feature-prefix-12-staging-prefix.vercel.app
+         *    longer-project-name-feature-prefix-12-staging-prefix.vercel.app
+         * 
+         * Therefore, if the alias would exceed 63 characters, we remove the
+         * stagingPrefix to have the longest branchName substring possible:
+         *    longer-project-name-feature-prefix-12345-my-feature.vercel.app
+         *    longer-project-name-feature-prefix-12346-my-second-f.vercel.app
         */
-        let aliasingBranchName = escapedBranchName;
         const branchNameAllowedLength = 50-projectName.length-stagingPrefix.length;
+        let aliasHostname = `${projectName}-${escapedBranchName}-${stagingPrefix}.vercel.app`;
+
         if (escapedBranchName.length > branchNameAllowedLength) {
-          aliasingBranchName = aliasingBranchName.substring(0, branchNameAllowedLength);
+          // Calculate the maximum length of the branchName by removing the stagingPrefix and the dash
+          const branchNameExtendedLength = branchNameAllowedLength+stagingPrefix.length+1;
+
+          let aliasingBranchName = escapedBranchName.substring(0, branchNameExtendedLength);;
 
           // If, after truncation, the last character is a dash, remove it
-          if (aliasingBranchName[branchNameAllowedLength] === '-') {
-            aliasingBranchName = aliasingBranchName.substring(0, branchNameAllowedLength-1)
+          if (aliasingBranchName[branchNameExtendedLength] === '-') {
+            aliasingBranchName = aliasingBranchName.substring(0, branchNameExtendedLength-1)
           }
+
+          // Remove the stagingPrefix from the aliasHostname and use the extended aliasingBranchName
+          aliasHostname = `${projectName}-${aliasingBranchName}.vercel.app`;
         }
-        const aliasHostname = `${projectName}-${aliasingBranchName}-${stagingPrefix}.vercel.app`;
+
         deployURL = `https://${aliasHostname}`;
         vercel = tool(which("vercel", true));
         const vercelAliasArgs = [

--- a/vercel-deployment-task-source/src/index.ts
+++ b/vercel-deployment-task-source/src/index.ts
@@ -237,11 +237,11 @@ async function run() {
         let aliasingBranchName = escapedBranchName;
         const branchNameAllowedLength = 52-projectName.length-stagingPrefix.length;
         if (escapedBranchName.length > branchNameAllowedLength) {
-          aliasingBranchName.substring(0, branchNameAllowedLength);
+          aliasingBranchName = aliasingBranchName.substring(0, branchNameAllowedLength);
 
           // If, after truncation, the last character is a dash, remove it
           if (aliasingBranchName[branchNameAllowedLength] === '-') {
-            aliasingBranchName.substring(0, branchNameAllowedLength-1)
+            aliasingBranchName = aliasingBranchName.substring(0, branchNameAllowedLength-1)
           }
         }
         const aliasHostname = `${projectName}-${aliasingBranchName}-${stagingPrefix}.vercel.app`;

--- a/vercel-deployment-task-source/task.json
+++ b/vercel-deployment-task-source/task.json
@@ -11,7 +11,7 @@
   "version": {
     "Major": 1,
     "Minor": 2,
-    "Patch": 3
+    "Patch": 4
   },
   "instanceNameFormat": "Deploying $(vercelProject) to Vercel",
   "inputs": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "manifestVersion": 1,
   "id": "vercel-deployment-extension",
   "name": "Vercel Deployment Extension",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "publisher": "Vercel",
   "public": true,
   "targets": [


### PR DESCRIPTION
Truncating branch name according to RFC 1035 if necessary 
Maximum length is 63 characters.

Read more: https://vercel.com/guides/why-is-my-vercel-deployment-url-being-shortened