### PR TITLE
Remove trailing dash `-` from aliasingBranchName

### DIFF
--- a/vercel-deployment-task-source/src/index.ts
+++ b/vercel-deployment-task-source/src/index.ts
@@ -258,8 +258,8 @@ async function run() {
           let aliasingBranchName = escapedBranchName.substring(0, branchNameExtendedLength);
 
           // If, after truncation, the last character is a dash, remove it
-          if (aliasingBranchName[branchNameExtendedLength] === '-') {
-            aliasingBranchName = aliasingBranchName.substring(0, branchNameExtendedLength-1)
+          if (aliasingBranchName.endsWith('-')) {
+            aliasingBranchName = aliasingBranchName.substring(0, aliasingBranchName.length - 1);
           }
 
           // Remove the stagingPrefix from the aliasHostname and use the extended aliasingBranchName

--- a/vercel-deployment-task-source/src/index.ts
+++ b/vercel-deployment-task-source/src/index.ts
@@ -221,45 +221,53 @@ async function run() {
           getProjectName(vercelProjectId, vercelOrgId, vercelToken),
           getStagingPrefix(vercelOrgId, vercelToken),
         ]);
-        const escapedBranchName = branchName.replace(/[^a-zA-Z0-9\-]-?/g, '-');
+        const escapedBranchName = branchName.replace(/[^a-zA-Z0-9\-]-?/g, "-");
         /**
-         * Truncating branch name according to RFC 1035 if necessary 
+         * Truncating branch name according to RFC 1035 if necessary
          * Maximum length is 63 characters.
-         * 
+         *
          * Read more: https://vercel.com/guides/why-is-my-vercel-deployment-url-being-shortened
-         * 
+         *
          * projectName has a fixedLength `x`
          * stagingPrefix has a fixedLenght `y`
          * .vercel.app has a fixedLength `11`
          * two dashes
-         * 
+         *
          * escapedBranchName can have a maximum length of 63-11-2-y-x
-         * 
+         *
          * This can cause confusion if you have all branches following a scheme, e.g.
          *    feature/PREFIX-12345-my-feature-branch-name
          *    feature/PREFIX-12346-my-second-feature-branch-name
-         * 
+         *
          * which can produce identical branchNames in the alias:
          *    longer-project-name-feature-prefix-12-staging-prefix.vercel.app
          *    longer-project-name-feature-prefix-12-staging-prefix.vercel.app
-         * 
+         *
          * Therefore, if the alias would exceed 63 characters, we remove the
          * stagingPrefix to have the longest branchName substring possible:
          *    longer-project-name-feature-prefix-12345-my-feature.vercel.app
          *    longer-project-name-feature-prefix-12346-my-second-f.vercel.app
-        */
-        const branchNameAllowedLength = 50-projectName.length-stagingPrefix.length;
+         */
+        const branchNameAllowedLength =
+          50 - projectName.length - stagingPrefix.length;
         let aliasHostname = `${projectName}-${escapedBranchName}-${stagingPrefix}.vercel.app`;
 
         if (escapedBranchName.length > branchNameAllowedLength) {
           // Calculate the maximum length of the branchName by removing the stagingPrefix and the dash
-          const branchNameExtendedLength = branchNameAllowedLength+stagingPrefix.length+1;
+          const branchNameExtendedLength =
+            branchNameAllowedLength + stagingPrefix.length + 1;
 
-          let aliasingBranchName = escapedBranchName.substring(0, branchNameExtendedLength);
+          let aliasingBranchName = escapedBranchName.substring(
+            0,
+            branchNameExtendedLength
+          );
 
           // If, after truncation, the last character is a dash, remove it
-          if (aliasingBranchName.endsWith('-')) {
-            aliasingBranchName = aliasingBranchName.substring(0, aliasingBranchName.length - 1);
+          if (aliasingBranchName.endsWith("-")) {
+            aliasingBranchName = aliasingBranchName.substring(
+              0,
+              aliasingBranchName.length - 1
+            );
           }
 
           // Remove the stagingPrefix from the aliasHostname and use the extended aliasingBranchName

--- a/vercel-deployment-task-source/task.json
+++ b/vercel-deployment-task-source/task.json
@@ -11,7 +11,7 @@
   "version": {
     "Major": 1,
     "Minor": 2,
-    "Patch": 4
+    "Patch": 5
   },
   "instanceNameFormat": "Deploying $(vercelProject) to Vercel",
   "inputs": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "manifestVersion": 1,
   "id": "vercel-deployment-extension",
   "name": "Vercel Deployment Extension",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "publisher": "Vercel",
   "public": true,
   "targets": [


### PR DESCRIPTION
Dash removal logic was broken due to how the position of the dash was referenced.

```
❌ if (aliasingBranchName[branchNameExtendedLength] === '-') {
✅ if (aliasingBranchName.endsWith('-')) {
```
[View in context](https://github.com/vercel/vercel-azure-devops-extension/commit/dc744f43144eb1456368022a51a762d6c08d3ecd#diff-95107e7dd26f4412b733218fefa0692d56ce8868e7e400070ae4521682c26a2cR261)

Related to: [Truncate branchName (if necessary) to meet RFC 1035 criteria #17](https://github.com/vercel/vercel-azure-devops-extension/pull/17)

---

🙇 Thank you for reporting and for your patience @RobertoArmas