### PR TITLE
fix: create pr comments in a resolved state

### DIFF
--- a/vercel-azdo-pr-comment-task-source/src/index.ts
+++ b/vercel-azdo-pr-comment-task-source/src/index.ts
@@ -46,7 +46,7 @@ async function run() {
               commentType: CommentType.System,
             },
           ],
-          status: CommentThreadStatus.Active,
+          status: CommentThreadStatus.Unknown,
         },
         repositoryId,
         parseInt(pullRequestId),

--- a/vercel-azdo-pr-comment-task-source/task.json
+++ b/vercel-azdo-pr-comment-task-source/task.json
@@ -11,7 +11,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 0
+    "Patch": 1
   },
   "instanceNameFormat": "Commenting on Pull Request",
   "inputs": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "manifestVersion": 1,
   "id": "vercel-deployment-extension",
   "name": "Vercel Deployment Extension",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "publisher": "Vercel",
   "public": true,
   "targets": [


### PR DESCRIPTION
Currently pr comments are created with the state 'Active'. If the [check for comment resolution](https://learn.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops&tabs=browser#check-for-comment-resolution) policy is enabled, every created pr comment has to be manually resolved before the pr can be merged.
This can be easily prevented by creating the pr comment with a status like 'Unknown'.