### PR TITLE
feat: predictable preview deployment aliases via pr id

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ The configuration inputs `vercelProjectID`, `vercelOrgID`, and `vercelToken` can
 
   Required: `false`
 
+- `prIdDeploymentURL`
+
+  Create a stable preview deployment alias from the DevOps pull request id and provide DevOps pull request id via `--build-env` flag to the internal Vercel CLI deploy operation.
+
+  Type: `boolean`
+
+  Default: `false`
+
+  Required: `false`
+
 #### Outputs
 
 - `deploymentURL`

--- a/vercel-deployment-task-source/task.json
+++ b/vercel-deployment-task-source/task.json
@@ -10,8 +10,8 @@
   "author": "Vercel",
   "version": {
     "Major": 1,
-    "Minor": 2,
-    "Patch": 5
+    "Minor": 3,
+    "Patch": 0
   },
   "instanceNameFormat": "Deploying $(vercelProject) to Vercel",
   "inputs": [
@@ -56,6 +56,13 @@
       "label": "Enable debug output",
       "required": false,
       "helpMarkDown": "Enable `--debug` output for the internal Vercel CLI operations."
+    },
+    {
+      "name": "prIdDeploymentURL",
+      "type": "boolean",
+      "label": "Use DevOps pull request id to generate to generate preview deployment URLs",
+      "required": false,
+      "helpMarkDown": "Create a stable preview deployment alias from the DevOps pull request id and provide DevOps pull request id via `--build-env` flag to the internal Vercel CLI deploy operation."
     }
   ],
   "outputVariables": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "manifestVersion": 1,
   "id": "vercel-deployment-extension",
   "name": "Vercel Deployment Extension",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "publisher": "Vercel",
   "public": true,
   "targets": [


### PR DESCRIPTION
I'm deploying multiple Next.js applications from a monorepo. These are being fused together by rewrites to appear like one application as described [here](https://nextjs.org/docs/pages/building-your-application/deploying/multi-zones). I would like to be able to preview the whole setup, therefore I need stable and predictable preview aliases for all deployed applications. This probably could be achieved with the current approach of using the branch names, but seems like quite a hassle due to the trimming of long branch names. Also the branch name is currently not being made available explicitly in the build step to utilise it to generate the required rewrites.

In order to achieve this I would like to propose these two changes:

Provide the Azure DevOps PR ID as a env var to the build via the [--build-env flag](https://vercel.com/docs/cli/deploy#build-env) for  the `vercel deploy` command.

Offer an alternative matching way to generate the deployment alias URLs.
Currently they are generated from project and branch name (simplified: `${projectName}-${branchName}.vercel.app`). Some parts might be trimmed if 63 chars in total are being exceeded. This would be quite a bit of logic to generate the rewrite urls in the Next config. Also the branch name isn't currently available at build time afaik (could be easily provided via `--build-env` as well – might be a nice to have addition).

Therefore I suggest the following alternative: `${projectName}-${pullRequestId}.vercel.app`.

In the Next config you can then easily generate rewrites for the corresponding application: 
```
{
  source: '/zone-a/:path*/',
  destination: `https://zone-a-app-${process.env.devopsPullRequestId}.vercel.app/:path*/`,
}
```

This obviously might be a breaking change for existing setups, therefore I suggest to provide this as opt-in only.

Unfortunately I'm not able to test and verify my changes easily. Therefore I tried to keep the change's footprint as small as possible.
