### PR TITLE
fix: revert to 1.3.0 (bump to 1.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ This extension contains Azure Pipelines tasks for automatically deploying your A
   - [Extension Set Up](#extension-set-up)
   - [Basic Pipeline Set Up](#basic-pipeline-set-up)
   - [Full Featured Pipeline Set Up](#full-featured-pipeline-set-up)
-  - [Env Vars](#env-vars)
-    - [Available Env Vars](#available-env-vars)
   - [Extension Reference](#extension-reference)
     - [Task: `vercel-deployment-task`](#task-vercel-deployment-task)
     - [Task: `vercel-azdo-pr-comment-task`](#task-vercel-azdo-pr-comment-task)
@@ -94,24 +92,6 @@ This guide will demonstrate how to improve the [Basic Pipeline Set Up](#basic-pi
 1. Push these changes to the repository, and set a [Build Policy](#azure-build-policy-set-up) for the `main` branch.
 1. Now create a new branch, push a commit, and open a PR against `main`. A new pipeline execution should trigger and it should create a preview deployment on Vercel as well as comment back on the PR with the preview URL.
 
-## Env Vars
-
-The extension provides a set of env vars if the option [Automatically exposing System Environment Variables](https://vercel.com/docs/projects/environment-variables/system-environment-variables) is enabled in the Project Settings. These vars are available in the build step and at run time.
-
-Based on the selected [Framework Preset](https://vercel.com/docs/deployments/configure-a-build#framework-preset) framework-specific env vars are set for the build step like with a [regular integration](https://vercel.com/docs/projects/environment-variables/system-environment-variables#framework-environment-variables).
-   > Note: This option is currently only available for Next.js.
-
-### Available Env Vars
-
-| DevOps Variable                                        | Generic                     | Next.js                                |
-| ------------------------------------------------------ | --------------------------- | -------------------------------------- |
-| Build.SourceVersion                                    | DEVOPS_GIT_COMMIT_SHA       | NEXT_PUBLIC_DEVOPS_GIT_COMMIT_SHA      |
-| System.PullRequest.SourceBranch/Build.SourceBranchName | DEVOPS_GIT_COMMIT_REF       | NEXT_PUBLIC_DEVOPS_GIT_COMMIT_REF      |
-| System.PullRequest.PullRequestId                       | DEVOPS_GIT_PULL_REQUEST_ID  | NEXT_PUBLIC_DEVOPS_GIT_PULL_REQUEST_ID |
-| "devops"                                               | DEVOPS_GIT_PROVIDER         | NEXT_PUBLIC_DEVOPS_GIT_PROVIDER        |
-| System.TeamProjectId                                   | DEVOPS_GIT_REPO_ID          | NEXT_PUBLIC_DEVOPS_GIT_REPO_ID         |
-| System.TeamProject                                     | DEVOPS_GIT_REPO_SLUG        | NEXT_PUBLIC_DEVOPS_GIT_REPO_SLUG       |
-
 ## Extension Reference
 
 ### Task: `vercel-deployment-task`
@@ -194,27 +174,11 @@ The configuration inputs `vercelProjectID`, `vercelOrgID`, and `vercelToken` can
 
   Required: `false`
 
-- `logs`
-
-  Enable `--logs` flag for the internal Vercel CLI operations.
-
-  Type: `boolean`
-
-  Default: `false`
-
-  Required: `false`
-
 #### Outputs
 
 - `deploymentURL`
 
   The URL of the deployment.
-
-  Type: `string`
-
-- `originalDeploymentURL`
-
-  Original URL of the deployment. Can be used to create your own alias in a separate task.
 
   Type: `string`
 

--- a/vercel-deployment-task-source/src/index.ts
+++ b/vercel-deployment-task-source/src/index.ts
@@ -47,15 +47,11 @@ async function getStagingPrefix(orgID: string, token: string): Promise<string> {
   return isTeam ? result.stagingPrefix : result.user.stagingPrefix;
 }
 
-// https://vercel.com/docs/rest-api/endpoints/projects#find-a-project-by-id-or-name-response
-type Framework = 'blitzjs' | 'nextjs' | 'gatsby' | 'remix' | 'astro' | 'hexo' | 'eleventy' | 'docusaurus-2' | 'docusaurus' | 'preact' | 'solidstart-1' | 'solidstart' | 'dojo' | 'ember' | 'vue' | 'scully' | 'ionic-angular' | 'angular' | 'polymer' | 'svelte' | 'sveltekit' | 'sveltekit-1' | 'ionic-react' | 'create-react-app' | 'gridsome' | 'umijs' | 'sapper' | 'saber' | 'stencil' | 'nuxtjs' | 'redwoodjs' | 'hugo' | 'jekyll' | 'brunch' | 'middleman' | 'zola' | 'hydrogen' | 'vite' | 'vitepress' | 'vuepress' | 'parcel' | 'fasthtml' | 'sanity' | 'storybook' | null;
-type Project = { autoExposeSystemEnvs: boolean; framework: Framework; name: string; }
-
-async function getProject(
+async function getProjectName(
   projectId: string,
   orgId: string,
   token: string
-): Promise<Project> {
+): Promise<string> {
   let apiURL = `https://api.vercel.com/v9/projects/${projectId}`;
   if (isTeamID(orgId)) {
     apiURL += `?teamId=${orgId}`;
@@ -76,7 +72,7 @@ async function getProject(
     );
   }
 
-  return result;
+  return result.name;
 }
 
 /**
@@ -134,8 +130,6 @@ async function run() {
     const debug = getBoolInput("debug");
 
     const archive = getBoolInput("archive");
-
-    const logs = getBoolInput("logs");
 
     const vercelProjectId = reconcileConfigurationInput(
       "vercelProjectId",
@@ -201,59 +195,6 @@ async function run() {
     if (archive) {
       vercelDeployArgs.push("--archive=tgz");
     }
-
-    if (logs) {
-      vercelDeployArgs.push("--logs");
-    }
-
-    const project = await getProject(vercelProjectId, vercelOrgId, vercelToken)
-
-    // Get branch name
-    // If triggered by a PR use `System.PullRequest.SourceBranch` (and replace the `refs/heads/`)
-    // If not triggered by a PR use `Build.SourceBranchName`
-    let branchName: string | undefined;
-    const buildReason = getVariable("Build.Reason");
-    if (buildReason === "PullRequest") {
-      branchName = getVariable("System.PullRequest.SourceBranch");
-      if (branchName) {
-        branchName = branchName.replace("refs/heads/", "");
-      }
-    } else {
-      branchName = getVariable("Build.SourceBranchName");
-    }
-
-    // adding predefined DevOps variables which can be useful during build as env vars in a similiar style as the regular Vercel git integration would (replacing VERCEL with DEVOPS)
-    if (project.autoExposeSystemEnvs) {
-      const addEnvVar = (envVar: string) => {
-        vercelDeployArgs.push('--build-env', envVar);
-        vercelDeployArgs.push('--env', envVar);
-      }
-
-      const commitSha = getVariable("Build.SourceVersion");
-      const pullRequestId = getVariable("System.PullRequest.PullRequestId");
-      const teamProject = getVariable("System.TeamProject");
-      const teamProjectId = getVariable("System.TeamProjectId");
-
-      addEnvVar(`DEVOPS_GIT_COMMIT_SHA=${commitSha}`);
-      addEnvVar(`DEVOPS_GIT_COMMIT_REF=${branchName}`);
-      addEnvVar(`DEVOPS_GIT_PULL_REQUEST_ID=${pullRequestId}`);
-      addEnvVar(`DEVOPS_GIT_PROVIDER=devops`);
-      addEnvVar(`DEVOPS_GIT_REPO_ID=${teamProjectId}`);
-      addEnvVar(`DEVOPS_GIT_REPO_SLUG=${teamProject}`);
-
-      // adding framework specific vars as with regular integration (currently only Next.js is supported) https://vercel.com/docs/projects/environment-variables/system-environment-variables#framework-environment-variables 
-      switch (project.framework) {
-        case 'nextjs':
-          vercelDeployArgs.push('--build-env', `NEXT_PUBLIC_DEVOPS_GIT_COMMIT_SHA=${commitSha}`);
-          vercelDeployArgs.push('--build-env', `NEXT_PUBLIC_DEVOPS_GIT_COMMIT_REF=${branchName}`);
-          vercelDeployArgs.push('--build-env', `NEXT_PUBLIC_DEVOPS_GIT_PULL_REQUEST_ID=${pullRequestId}`);
-          vercelDeployArgs.push('--build-env', `NEXT_PUBLIC_DEVOPS_GIT_PROVIDER=devops`);
-          vercelDeployArgs.push('--build-env', `NEXT_PUBLIC_DEVOPS_GIT_REPO_ID=${teamProjectId}`);
-          vercelDeployArgs.push('--build-env', `NEXT_PUBLIC_DEVOPS_GIT_REPO_SLUG=${teamProject}`);
-          break;
-      }
-    }
-
     const vercelDeploy = vercel.arg(vercelDeployArgs);
     ({ stdout, stderr, code } = vercelDeploy.execSync());
 
@@ -263,12 +204,28 @@ async function run() {
       );
     }
 
-    const originalDeployURL = stdout;
-    let deployURL = originalDeployURL;
+    let deployURL = stdout;
 
     if (!deployToProduction) {
+      // Get branch name
+      // If triggered by a PR use `System.PullRequest.SourceBranch` (and replace the `refs/heads/`)
+      // If not triggered by a PR use `Build.SourceBranchName`
+      let branchName: string | undefined;
+      const buildReason = getVariable("Build.Reason");
+      if (buildReason && buildReason === "PullRequest") {
+        branchName = getVariable("System.PullRequest.SourceBranch");
+        if (branchName) {
+          branchName = branchName.replace("refs/heads/", "");
+        }
+      } else {
+        branchName = getVariable("Build.SourceBranchName");
+      }
+
       if (branchName) {
-        const stagingPrefix = await getStagingPrefix(vercelOrgId, vercelToken);
+        const [projectName, stagingPrefix] = await Promise.all([
+          getProjectName(vercelProjectId, vercelOrgId, vercelToken),
+          getStagingPrefix(vercelOrgId, vercelToken),
+        ]);
         const escapedBranchName = branchName.replace(/[^a-zA-Z0-9\-]-?/g, "-");
         /**
          * Truncating branch name according to RFC 1035 if necessary
@@ -276,7 +233,7 @@ async function run() {
          *
          * Read more: https://vercel.com/guides/why-is-my-vercel-deployment-url-being-shortened
          *
-         * project.name has a fixedLength `x`
+         * projectName has a fixedLength `x`
          * stagingPrefix has a fixedLenght `y`
          * .vercel.app has a fixedLength `11`
          * two dashes
@@ -297,8 +254,8 @@ async function run() {
          *    longer-project-name-feature-prefix-12346-my-second-f.vercel.app
          */
         const branchNameAllowedLength =
-          50 - project.name.length - stagingPrefix.length;
-        let aliasHostname = `${project.name}-${escapedBranchName}-${stagingPrefix}.vercel.app`;
+          50 - projectName.length - stagingPrefix.length;
+        let aliasHostname = `${projectName}-${escapedBranchName}-${stagingPrefix}.vercel.app`;
 
         if (escapedBranchName.length > branchNameAllowedLength) {
           // Calculate the maximum length of the branchName by removing the stagingPrefix and the dash
@@ -319,7 +276,7 @@ async function run() {
           }
 
           // Remove the stagingPrefix from the aliasHostname and use the extended aliasingBranchName
-          aliasHostname = `${project.name}-${aliasingBranchName}.vercel.app`;
+          aliasHostname = `${projectName}-${aliasingBranchName}.vercel.app`;
         }
 
         deployURL = `https://${aliasHostname}`;
@@ -348,7 +305,6 @@ async function run() {
       }
     }
 
-    setVariable("originalDeploymentURL", originalDeployURL, false, true);
     setVariable("deploymentURL", deployURL, false, true);
     const message = `Successfully deployed to ${deployURL}`;
     setVariable("deploymentTaskMessage", message, false, true);

--- a/vercel-deployment-task-source/task.json
+++ b/vercel-deployment-task-source/task.json
@@ -10,7 +10,7 @@
   "author": "Vercel",
   "version": {
     "Major": 1,
-    "Minor": 3,
+    "Minor": 6,
     "Patch": 0
   },
   "instanceNameFormat": "Deploying $(vercelProject) to Vercel",

--- a/vercel-deployment-task-source/task.json
+++ b/vercel-deployment-task-source/task.json
@@ -10,8 +10,8 @@
   "author": "Vercel",
   "version": {
     "Major": 1,
-    "Minor": 5,
-    "Patch": 1
+    "Minor": 3,
+    "Patch": 0
   },
   "instanceNameFormat": "Deploying $(vercelProject) to Vercel",
   "inputs": [
@@ -63,23 +63,12 @@
       "label": "Enable compression of the deployment code into a single file before uploading it",
       "required": false,
       "helpMarkDown": "Enable `--archive=tgz` flag for the internal Vercel CLI operations."
-    },
-    {
-      "name": "logs",
-      "type": "boolean",
-      "label": "Enable build log output in the pipeline",
-      "required": false,
-      "helpMarkDown": "Enable `--logs` flag for the internal Vercel CLI operations."
     }
   ],
   "outputVariables": [
     {
       "name": "deploymentURL",
       "description": "The URL of the deployment."
-    },
-    {
-      "name": "originalDeploymentURL",
-      "description": "Original URL of the deployment. Can be used to create your own alias in a separate task."
     },
     {
       "name": "deploymentTaskMessage",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "manifestVersion": 1,
   "id": "vercel-deployment-extension",
   "name": "Vercel Deployment Extension",
-  "version": "1.5.1",
+  "version": "1.3.1",
   "publisher": "Vercel",
   "public": true,
   "targets": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "manifestVersion": 1,
   "id": "vercel-deployment-extension",
   "name": "Vercel Deployment Extension",
-  "version": "1.3.1",
+  "version": "1.6.0",
   "publisher": "Vercel",
   "public": true,
   "targets": [


### PR DESCRIPTION
The result of `git revert -n HEAD~4..HEAD` to bring us back to fbaa9710fb84fe3167591398bb77d25ecfd98562.

Reverts:
- https://github.com/vercel/vercel-azure-devops-extension/pull/31
- https://github.com/vercel/vercel-azure-devops-extension/pull/29
- https://github.com/vercel/vercel-azure-devops-extension/pull/30
- https://github.com/vercel/vercel-azure-devops-extension/pull/27

With the aim of addressing issues like: https://github.com/vercel/vercel-azure-devops-extension/issues/32

Version has been bumped to `1.6.0` as it's most common for users of this library to pin to the major version.