### PR TITLE
Bump patch version

### DIFF
--- a/vercel-deployment-task-source/task.json
+++ b/vercel-deployment-task-source/task.json
@@ -11,7 +11,7 @@
   "version": {
     "Major": 1,
     "Minor": 6,
-    "Patch": 4
+    "Patch": 5
   },
   "instanceNameFormat": "Deploying $(vercelProject) to Vercel",
   "inputs": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "manifestVersion": 1,
   "id": "vercel-deployment-extension",
   "name": "Vercel Deployment Extension",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "publisher": "Vercel",
   "public": true,
   "targets": [


### PR DESCRIPTION
Bump the version of the extension since I forgot to do that in https://github.com/vercel/vercel-azure-devops-extension/pull/44.