### PR TITLE
feat: add support for target option

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,16 @@ The configuration inputs `vercelProjectID`, `vercelOrgID`, and `vercelToken` can
 
   Required: `false`
 
+- `target`
+
+  Option to define the environment you want to deploy to. This could be production, preview, or a custom environment. For more information, see [Using an environment through the Vercel CLI](https://vercel.com/docs/deployments/custom-environments#using-an-environment-through-the-vercel-cli).
+
+  Type: `string`
+
+  Default: `false`
+
+  Required: `false`
+
 - `debug`
 
   Enable `--debug` output for the internal Vercel CLI operations.

--- a/vercel-deployment-task-source/src/index.ts
+++ b/vercel-deployment-task-source/src/index.ts
@@ -128,6 +128,8 @@ async function run() {
   try {
     setResourcePath(path.join(__dirname, "..", "task.json"));
 
+    const target = getInput("target");
+
     const debug = getBoolInput("debug");
 
     const archive = getBoolInput("archive");
@@ -194,6 +196,9 @@ async function run() {
       : ["deploy", `--token=${vercelToken}`];
     if (vercelCurrentWorkingDirectory) {
       vercelDeployArgs.push(`--cwd=${vercelCurrentWorkingDirectory}`);
+    }
+    if (target) {
+      vercelDeployArgs.push(`--target=${target}`);
     }
     if (debug) {
       vercelDeployArgs.push("--debug");

--- a/vercel-deployment-task-source/task.json
+++ b/vercel-deployment-task-source/task.json
@@ -10,8 +10,8 @@
   "author": "Vercel",
   "version": {
     "Major": 1,
-    "Minor": 6,
-    "Patch": 5
+    "Minor": 7,
+    "Patch": 0
   },
   "instanceNameFormat": "Deploying $(vercelProject) to Vercel",
   "inputs": [
@@ -49,6 +49,13 @@
       "label": "Deploy to Production",
       "required": false,
       "helpMarkDown": "Should the task deploy to production? Defaults to false"
+    },
+    {
+      "name": "target",
+      "type": "string",
+      "label": "Environment to deploy to",
+      "required": false,
+      "helpMarkDown": "Option to define the environment you want to deploy to. This could be production, preview, or a custom environment. For more information, see [Using an environment through the Vercel CLI](https://vercel.com/docs/deployments/custom-environments#using-an-environment-through-the-vercel-cli)."
     },
     {
       "name": "debug",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "manifestVersion": 1,
   "id": "vercel-deployment-extension",
   "name": "Vercel Deployment Extension",
-  "version": "1.6.5",
+  "version": "1.7.0",
   "publisher": "Vercel",
   "public": true,
   "targets": [


### PR DESCRIPTION
Adding support for the new [target option](https://vercel.com/docs/deployments/custom-environments#using-an-environment-through-the-vercel-cli).