### PR TITLE
fix: vercel cli still requires VERCEL_ORG_ID env var

### DIFF
--- a/vercel-deployment-task-source/src/index.ts
+++ b/vercel-deployment-task-source/src/index.ts
@@ -151,6 +151,9 @@ async function run() {
       );
     }
 
+    // VERCEL_ORG_ID is still required internally
+    setVariable("VERCEL_ORG_ID", vercelTeamId);
+
     const vercelToken = reconcileConfigurationInput(
       "vercelToken",
       "VERCEL_TOKEN",

--- a/vercel-deployment-task-source/task.json
+++ b/vercel-deployment-task-source/task.json
@@ -11,7 +11,7 @@
   "version": {
     "Major": 3,
     "Minor": 0,
-    "Patch": 0
+    "Patch": 1
   },
   "instanceNameFormat": "Deploying $(vercelProject) to Vercel",
   "inputs": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "manifestVersion": 1,
   "id": "vercel-deployment-extension",
   "name": "Vercel Deployment Extension",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "publisher": "Vercel",
   "public": true,
   "targets": [


### PR DESCRIPTION
Version 2 introduced an issue with the Vercel CLI, which seems to still use the `VERCEL_ORG_ID` implicitly. By changing the envs name to `VERCEL_TEAM_ID` this was broken, can be seen in this run:
https://dev.azure.com/philippdollst/azdo-vercel-microfrontend-previews/_build/results?buildId=39&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=c40fb2b7-52be-5f30-27ae-93b0ff067608&l=27

When the `VERCEL_ORG_ID` is provided the run will succeed with v3 and the Node deprecation warnings disappear as expected: https://dev.azure.com/philippdollst/azdo-vercel-microfrontend-previews/_build/results?buildId=37&view=results

Difference between first and second run in the pipeline: https://dev.azure.com/philippdollst/azdo-vercel-microfrontend-previews/_git/microfrontends-preview/commit/3d66eeaf615e15a3c771be2c027323bf58cc9e1b?refName=refs%2Fheads%2Fplugin-v3

The change in this PR should be the least invasive workaround to fix this for now

@paulogdm Sorry for the delayed feedback - was kinda busy lately... would appreciate if you could take look into this soonish to unblock v3 and everyone cat get away from the Node 16 deprecation! I'll rerun the pipeline as soon as there's preview and in theory it should just work