### PR TITLE
Add --cwd argument to vercel pull command #1

### DIFF
--- a/vercel-deployment-task-source/src/index.ts
+++ b/vercel-deployment-task-source/src/index.ts
@@ -197,6 +197,9 @@ async function run() {
       `--environment=${deployToProduction ? "production" : "preview"}`,
       `--token=${vercelToken}`,
     ];
+    if (vercelCurrentWorkingDirectory) {
+      vercelPullArgs.push(`--cwd=${vercelCurrentWorkingDirectory}`);
+    }
     if (debug) {
       vercelPullArgs.push("--debug");
     }


### PR DESCRIPTION
### Problem
When using `vercel pull`  to deploy a project in a subdirector the vercel pull command runs without the `--cwd` argument, while vercel deploy correctly includes it.

This causes vercel pull to create the .`vercel/ `folder in the repository root, but `vercel deploy --cwd=<path>` looks for it in the subdirectory. Since the `.vercel/project.json` isn't found, Vercel cannot detect the framework configuration.

This results in "No framework detected" in deployment logs and Only static assets being deployed instead of the full application (serverless functions, SSR pages, etc.)
<img width="1935" height="750" alt="image" src="https://github.com/user-attachments/assets/4784e08b-a3ad-49cc-9f8b-353bd4dd0cae" />

### Fix
Add the --cwd argument to vercelPullArgs when vercelCurrentWorkingDirectory.

### Testing
I _have not_ tested this (apologies), but we've included this in our workaround in a pipeline.