### PR TITLE
fix: harden CLI output handling in deployment task

### DIFF
--- a/vercel-azdo-pr-comment-task-source/src/index.ts
+++ b/vercel-azdo-pr-comment-task-source/src/index.ts
@@ -16,6 +16,22 @@ function errorHandler(error: unknown) {
   setResult(TaskResult.Failed, `Unknown error thrown: ${error}`);
 }
 
+/**
+ * Defense-in-depth secret scrubbing for any text we are about to post as a
+ * pull request comment. The deployment task already redacts before writing
+ * `deploymentTaskMessage`, but we re-scrub here so future regressions or
+ * user-provided messages cannot leak Vercel tokens into PR threads.
+ */
+function redactSecrets(text: string): string {
+  if (!text) return text;
+  return text
+    .replace(/vcp_[A-Za-z0-9_-]+/g, "vcp_***")
+    .replace(/vca_[A-Za-z0-9_-]+/g, "vca_***")
+    .replace(/(--token[= ])[^\s"']+/g, "$1***")
+    .replace(/([?&]token=)[^\s&"']+/g, "$1***")
+    .replace(/(Bearer\s+)[A-Za-z0-9._-]+/gi, "$1***");
+}
+
 process.on("unhandledRejection", errorHandler);
 process.on("unhandledException", errorHandler);
 
@@ -23,7 +39,7 @@ async function run() {
   try {
     setResourcePath(path.join(__dirname, "..", "task.json"));
 
-    const message = getInput("deploymentTaskMessage", true)!;
+    const message = redactSecrets(getInput("deploymentTaskMessage", true)!);
 
     const buildReason = getVariable("Build.Reason");
     if (buildReason === "PullRequest") {

--- a/vercel-azdo-pr-comment-task-source/task.json
+++ b/vercel-azdo-pr-comment-task-source/task.json
@@ -11,7 +11,7 @@
   "version": {
     "Major": 3,
     "Minor": 0,
-    "Patch": 0
+    "Patch": 1
   },
   "instanceNameFormat": "Commenting on Pull Request",
   "inputs": [

--- a/vercel-deployment-task-source/src/index.ts
+++ b/vercel-deployment-task-source/src/index.ts
@@ -24,6 +24,33 @@ function isTeamID(teamId: string) {
   return teamId.startsWith("team_");
 }
 
+/**
+ * Mask Vercel tokens and Authorization headers anywhere they might appear in
+ * a string before it is logged, surfaced as an output variable, or posted as
+ * a PR comment. Newer Vercel CLI versions print follow-up commands that echo
+ * the `--token=...` value back, so anything sourced from CLI stdout/stderr
+ * must be passed through here.
+ */
+function redactSecrets(text: string): string {
+  if (!text) return text;
+  return text
+    .replace(/vcp_[A-Za-z0-9_-]+/g, "vcp_***")
+    .replace(/vca_[A-Za-z0-9_-]+/g, "vca_***")
+    .replace(/(--token[= ])[^\s"']+/g, "$1***")
+    .replace(/([?&]token=)[^\s&"']+/g, "$1***")
+    .replace(/(Bearer\s+)[A-Za-z0-9._-]+/gi, "$1***");
+}
+
+/**
+ * Pick the deployment URL out of `vercel deploy` stdout. The CLI may print
+ * additional lines (warnings, JSON-shaped follow-up hints), so we cannot use
+ * the entire stdout as the URL.
+ */
+function extractDeploymentURL(stdout: string): string {
+  const urlMatch = stdout.match(/https?:\/\/[^\s"']+/);
+  return urlMatch ? urlMatch[0] : "";
+}
+
 async function getStagingPrefix(teamId: string, token: string): Promise<string> {
   const { statusCode, body } = await request(`https://api.vercel.com/v2/teams/${teamId}`, {
     headers: {
@@ -84,7 +111,8 @@ function reconcileConfigurationInput(
   inputKey: string,
   envVarKey: string,
   name: string,
-  defaultValue?: string
+  defaultValue?: string,
+  secret = false
 ): string {
   const inputValue = getInput(inputKey);
   const envVarValue = getVariable(envVarKey);
@@ -96,7 +124,7 @@ function reconcileConfigurationInput(
   }
 
   if (inputValue) {
-    setVariable(envVarKey, inputValue);
+    setVariable(envVarKey, inputValue, secret);
     return inputValue;
   }
 
@@ -105,7 +133,7 @@ function reconcileConfigurationInput(
   }
 
   if (defaultValue) {
-    setVariable(envVarKey, defaultValue);
+    setVariable(envVarKey, defaultValue, secret);
     return defaultValue;
   }
 
@@ -157,7 +185,9 @@ async function run() {
     const vercelToken = reconcileConfigurationInput(
       "vercelToken",
       "VERCEL_TOKEN",
-      "Vercel Token"
+      "Vercel Token",
+      undefined,
+      true
     );
 
     const vercelCurrentWorkingDirectory = reconcileConfigurationInput(
@@ -186,7 +216,7 @@ async function run() {
 
     if (code !== 0) {
       throw new Error(
-        `npm install failed with exit code ${code}. Error: ${stderr}`
+        `npm install failed with exit code ${code}. Error: ${redactSecrets(stderr)}`
       );
     }
 
@@ -235,12 +265,18 @@ async function run() {
 
     if (code !== 0) {
       throw new Error(
-        `vercel deploy failed with exit code ${code}. Error: ${stderr}`
+        `vercel deploy failed with exit code ${code}. Error: ${redactSecrets(stderr)}`
       );
     }
 
-    const originalDeployURL = stdout;
-    let deployURL = stdout;
+    const originalDeployURL = extractDeploymentURL(stdout);
+    let deployURL = originalDeployURL;
+
+    if (!originalDeployURL) {
+      throw new Error(
+        `vercel deploy did not return a deployment URL.`
+      );
+    }
 
     if (!deployToProduction) {
       // Get branch name
@@ -323,7 +359,7 @@ async function run() {
         vercel = tool(which("vercel", true));
         const vercelAliasArgs = [
           "alias",
-          stdout,
+          originalDeployURL,
           aliasHostname,
           `--token=${vercelToken}`,
           `--scope=${vercelTeamId}`,
@@ -335,7 +371,7 @@ async function run() {
         ({ stdout, stderr, code } = vercelAlias.execSync());
         if (code !== 0) {
           throw new Error(
-            `vercel alias failed with exit code ${code}. Error: ${stderr}`
+            `vercel alias failed with exit code ${code}. Error: ${redactSecrets(stderr)}`
           );
         }
       } else {
@@ -347,7 +383,7 @@ async function run() {
 
     setVariable("originalDeploymentURL", originalDeployURL, false, true);
     setVariable("deploymentURL", deployURL, false, true);
-    const message = `Successfully deployed to ${deployURL}`;
+    const message = redactSecrets(`Successfully deployed to ${deployURL}`);
     setVariable("deploymentTaskMessage", message, false, true);
     console.log(message);
 

--- a/vercel-deployment-task-source/task.json
+++ b/vercel-deployment-task-source/task.json
@@ -11,7 +11,7 @@
   "version": {
     "Major": 3,
     "Minor": 0,
-    "Patch": 1
+    "Patch": 2
   },
   "instanceNameFormat": "Deploying $(vercelProject) to Vercel",
   "inputs": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "manifestVersion": 1,
   "id": "vercel-deployment-extension",
   "name": "Vercel Deployment Extension",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "publisher": "Vercel",
   "public": true,
   "targets": [


### PR DESCRIPTION
## Summary

  - Tightens how the deployment task captures and forwards `vercel` CLI output. Only the deployment URL is now extracted from stdout; the rest is discarded so unrelated CLI output
  does not flow into pipeline output variables, logs, or PR comments.
  - Adds defensive scrubbing of known sensitive token patterns at every output boundary in both tasks.
  - Marks `VERCEL_TOKEN` as a secret variable when populated from the task input, so the Azure DevOps log scrubber masks it in pipeline logs.
  - Patch-bumps both tasks and the extension manifest.